### PR TITLE
Use backtick or "4 spaces" code formatting styles when possible, code copied from TIO

### DIFF
--- a/frontend/lib/codeToMarkdown.ts
+++ b/frontend/lib/codeToMarkdown.ts
@@ -1,0 +1,34 @@
+const rLineOfSpaces = /^\s+$/m;
+const rSurroundingLinefeed = /^\n|\n$/;
+// eslint-disable-next-line no-control-regex
+const rUnprintable = /[\x00-\x09\x0b-\x1f\x7f-\x9f]/;
+// eslint-disable-next-line no-control-regex
+const rEscapees = /[\x00-\x09\x0b-\x1f\x7f-\x9f&<>]| $/gm;
+const rLineOfBackticks = /^\s*```\s*$/m;
+const rNewLine = /^/gm;
+
+export default function codeToMarkdown(code: string, language: string | undefined): string {
+  if (code === '') {
+    return '<pre><code></code></pre>';
+  } if (!rLineOfBackticks.test(code) && !rUnprintable.test(code)) {
+    return `\`\`\`${language ?? ''}\n${code}\n\`\`\`\``;
+  } if (rLineOfSpaces.test(code) || rSurroundingLinefeed.test(code) || rUnprintable.test(code)) {
+    return `<pre><code>${code.replace(rEscapees, character => {
+      switch (character) {
+        case '\0':
+          return '';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '&':
+          return '&amp;';
+        default:
+          return `&#${character.charCodeAt(0)};`;
+      }
+    })}\n</code></pre>`;
+  }
+
+  return `<!-- language: lang-${language ?? ''} -->\n${
+    code.replace(rNewLine, '    ')}`;
+}

--- a/frontend/lib/codeToMarkdown.ts
+++ b/frontend/lib/codeToMarkdown.ts
@@ -8,12 +8,13 @@ const rLineOfBackticks = /^\s*```\s*$/m;
 const rNewLine = /^/gm;
 
 export default function codeToMarkdown(code: string, language: string | undefined): string {
+  const langComment = language ? `<!-- language: lang-${language} -->\n` : '';
   if (code === '') {
     return '<pre><code></code></pre>';
   } if (!rLineOfBackticks.test(code) && !rUnprintable.test(code)) {
     return `\`\`\`${language ?? ''}\n${code}\n\`\`\`\``;
   } if (rLineOfSpaces.test(code) || rSurroundingLinefeed.test(code) || rUnprintable.test(code)) {
-    return `<pre><code>${code.replace(rEscapees, character => {
+    return `${langComment}<pre><code>${code.replace(rEscapees, character => {
       switch (character) {
         case '\0':
           return '';
@@ -29,6 +30,5 @@ export default function codeToMarkdown(code: string, language: string | undefine
     })}\n</code></pre>`;
   }
 
-  return `<!-- language: lang-${language ?? ''} -->\n${
-    code.replace(rNewLine, '    ')}`;
+  return `${langComment}${code.replace(rNewLine, '    ')}`;
 }

--- a/frontend/pages/run.tsx
+++ b/frontend/pages/run.tsx
@@ -19,6 +19,7 @@ import * as API from 'lib/api';
 import { save, load } from 'lib/urls';
 import { ENCODERS, DECODERS } from 'lib/encoding';
 import stringLength from 'lib/stringLength';
+import codeToMarkdown from '../lib/codeToMarkdown';
 
 const NEWLINE = '\n'.charCodeAt(0);
 
@@ -342,21 +343,17 @@ function _Run(
       return;
     }
     setClipboardCopyModalOpen(false);
-    let syntaxHighlightingClass: string;
-    if (languages[language].SE_class) {
-      syntaxHighlightingClass = ` class="lang-${escape(languages[language].SE_class)}"`;
-    } else {
-      syntaxHighlightingClass = '';
-    }
     let title: string;
     if (languages[language].url) {
       title = `[${languages[language].name}](${languages[language].url})`;
     } else {
       title = languages[language].name;
     }
+
+    const markdownCode = codeToMarkdown(code, languages[language].SE_class);
     navigator.clipboard.writeText(`# ${title}, ${byteLength} ${pluralise('byte', byteLength)}
 
-<pre><code${syntaxHighlightingClass}>${escape(code)}</code></pre>
+${markdownCode}
 
 [Attempt This Online!](${getCurrentURL()})`);
 

--- a/frontend/pages/run.tsx
+++ b/frontend/pages/run.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import {
   SyntheticEvent, useMemo, useRef, useState, useEffect,
 } from 'react';
-import { escape, throttle } from 'lodash';
+import { throttle } from 'lodash';
 import { ExclamationCircleIcon, ClipboardCopyIcon, XIcon } from '@heroicons/react/solid';
 
 import CollapsibleText from 'components/collapsibleText';


### PR DESCRIPTION
# Test cases:

## [Rust](https://www.rust-lang.org), 26 bytes

<pre><code>er was eens een muis
```&#9;&#9;
</code></pre>

[Attempt This Online!](https://localhost:3000/run?1=m72kqLS4ZMGCpaUlaboWu1KLFMoTixVSU_PAhEJuaWYxV0JCAicnRAFUHUw9AA)

## [Rust](https://www.rust-lang.org), 20 bytes

```rust
er was eens een muis
````

[Attempt This Online!](https://localhost:3000/run?1=m72kqLS4ZMGCpaUlaboWW1KLFMoTixVSU_PAhEJuaWYxRAqqAqYSAA)

## [Rust](https://www.rust-lang.org), 22 bytes

```rust
er was eens een muis


````

[Attempt This Online!](https://localhost:3000/run?1=m72kqLS4ZMGCpaUlaboW21KLFMoTixVSU_PAhEJuaWYxFxdEEqoGphYA)

## [Rust](https://www.rust-lang.org), 25 bytes

<pre><code>er was eens een muis
```

</code></pre>

[Attempt This Online!](https://localhost:3000/run?1=m72kqLS4ZMGCpaUlaboWO1OLFMoTixVSU_PAhEJuaWYxV0JCAhdEHqoMphwA)

## [Rust](https://www.rust-lang.org), 24 bytes

<!-- language: lang-rust -->
    er was eens een muis
    ```

[Attempt This Online!](https://localhost:3000/run?1=m72kqLS4ZMGCpaUlaboWO1KLFMoTixVSU_PAhEJuaWYxV0JCAkQaqgqmGgA)
