### PR TITLE
Add .pi extension to Picat code

### DIFF
--- a/runners/picat
+++ b/runners/picat
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 cd /ATO/context
-/ATO/yargs %1 /ATO/options /ATO/yargs %2 /ATO/arguments /opt/picat/picat %1 /ATO/code %2 < /ATO/input
+mv /ATO/code /ATO/code.pi
+/ATO/yargs %1 /ATO/options /ATO/yargs %2 /ATO/arguments /opt/picat/picat %1 /ATO/code.pi %2 < /ATO/input


### PR DESCRIPTION
Apparently Picat does not recognize the script file without `.pi` extension.