### PR TITLE
use base image for bash

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -50,7 +50,7 @@
     "bash": {
         "name": "Bash",
         "hello_world": {"code": "echo \"Hello, World!\"", "output": "Hello, World!\n"},
-        "image": "registry.gitlab.pxeger.com/attempt-this-online/languages/bash:latest",
+        "image": "registry.gitlab.pxeger.com/attempt-this-online/languages/base:latest",
         "version": "Latest",
         "url": "https://www.gnu.org/software/bash/",
         "sbcs": false,

--- a/runners/bash
+++ b/runners/bash
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd /ATO/context
-/ATO/yargs %1 /ATO/options /ATO/yargs %2 /ATO/arguments /usr/local/bin/bash %1 /ATO/code %2 < /ATO/input
+/ATO/yargs %1 /ATO/options /ATO/yargs %2 /ATO/arguments bash %1 /ATO/code %2 </ATO/input


### PR DESCRIPTION
Arch-packaged bash is reliably up to date, and this way I don't have to maintain the build
