### PR TITLE
fix http2 config in setup/nginx.conf

### DIFF
--- a/setup/nginx.conf
+++ b/setup/nginx.conf
@@ -57,8 +57,9 @@ http {
     limit_req_zone $binary_remote_addr zone=limit_api:8M rate=20r/m;
 
     server {
-        listen 443 ssl http2;
-        listen [::]:443 ssl http2;
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
         server_name ato.pxeger.com; #### CHANGE ####
         root /usr/local/share/ATO/public;
 


### PR DESCRIPTION
`listen http` syntax is deprecated
